### PR TITLE
Set AVAudioSession category as record type

### DIFF
--- a/packages/audio_streamer/ios/Classes/SwiftAudioStreamerPlugin.swift
+++ b/packages/audio_streamer/ios/Classes/SwiftAudioStreamerPlugin.swift
@@ -47,6 +47,9 @@ public class SwiftAudioStreamerPlugin: NSObject, FlutterPlugin, FlutterStreamHan
 
     func startRecording() {
         engine = AVAudioEngine()
+      
+        try! AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.record)
+      
         let input = engine.inputNode
         let bus = 0
 


### PR DESCRIPTION
Ensure that the AVAudioSession category is set to "AVAudioSession.Category.record" before starting to record